### PR TITLE
fix: use variable interpolation

### DIFF
--- a/setup-js/action.yml
+++ b/setup-js/action.yml
@@ -53,7 +53,8 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run:
-        ${{ inputs.package-manager }} install ${{ inputs.no-frozen-lockfile ==
-        'true' && '--no-frozen-lockfile' || '' }}
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
+        NO_FROZEN_LOCKFILE: ${{ inputs.no-frozen-lockfile == 'true' && '--no-frozen-lockfile' || '' }}
+      run: "$PACKAGE_MANAGER install $NO_FROZEN_LOCKFILE"
       if: ${{ inputs.auto-install }}

--- a/setup-js/action.yml
+++ b/setup-js/action.yml
@@ -56,5 +56,5 @@ runs:
       env:
         PACKAGE_MANAGER: ${{ inputs.package-manager }}
         NO_FROZEN_LOCKFILE: ${{ inputs.no-frozen-lockfile == 'true' && '--no-frozen-lockfile' || '' }}
-      run: "$PACKAGE_MANAGER install $NO_FROZEN_LOCKFILE"
+      run: $PACKAGE_MANAGER install $NO_FROZEN_LOCKFILE
       if: ${{ inputs.auto-install }}


### PR DESCRIPTION
## Summary
Harden input handling in `setup-js/action.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `setup-js/action.yml:56` |
| **Assessment** | Defensive hardening |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `setup-js/action.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
